### PR TITLE
Fix margin class typo

### DIFF
--- a/spacing/mixin.scss
+++ b/spacing/mixin.scss
@@ -116,7 +116,7 @@ $default-options: () !default;
       }
     }
 
-    .-ml {
+    .ml {
       @include options($margin, $props...) using ($value) {
         margin-left: $value;
       }


### PR DESCRIPTION
Hi 👋🏻

First of all, thanks for putting some effort and creating this awesome utility. 

I'm trying to use it in a project as a way to check if it is viable to generate some useful class helpers for the project. 

I noticed a typo for `margin-left` classes and create this PR to address this issue.


PS: I'm still figuring how to use `@snug/core` to generate other class utilities for me. It seems very promissing!

